### PR TITLE
Add SourceLink to NuGet package

### DIFF
--- a/EverythingSearchClient/EverythingSearchClient.csproj
+++ b/EverythingSearchClient/EverythingSearchClient.csproj
@@ -18,6 +18,9 @@
     <PackageReadmeFile>README_nuget.md</PackageReadmeFile>
     <PackageIcon>MagnifyingGlass_x128.png</PackageIcon>
     <PackageTags>Voidtools;Everything;Search</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,6 +32,10 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Adds `Microsoft.SourceLink.GitHub` to `EverythingSearchClient.csproj` so the packed NuGet package embeds repository/commit metadata and a GitHub source-link map in the PDB, letting consumers step into the library's source from their IDE.
- Sets `PublishRepositoryUrl` and `EmbedUntrackedSources`.
- Gates `ContinuousIntegrationBuild` on `$(GITHUB_ACTIONS)` so local builds keep machine-relative paths while CI builds are deterministic. No workflow changes were needed since `dotnet-desktop.yml` already checks out with `fetch-depth: 0`.

Fixes #21

## Test plan
- [x] `dotnet build --configuration Release` succeeds and produces `EverythingSearchClient.0.9.0.nupkg`
- [x] Verified the generated `.nuspec`'s `<repository>` element now includes the commit hash
- [x] Verified the built `.pdb` contains an embedded `raw.githubusercontent.com/.../<commit>/*` source-link URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)